### PR TITLE
proposed fix for json file reading issue

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -479,7 +479,7 @@ $("#local-files").change(function(e) {
     alert("Please select one video (.mp4) and one track (.json) file.");
   } else {
     $.each(files, function(index, file) {
-      if (file.type == "application/json") {
+      if (file.type == "application/json" || (file.name && file.name.endsWith('.json'))) {
         var reader = new FileReader();
         reader.onload = function(e) {
           trackJSON = JSON.parse(reader.result);


### PR DESCRIPTION
This was just a simple patch for #2.

We probably need to change ```.endsWith``` to something else, since that method is [not supported in some browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#Browser_compatibility).